### PR TITLE
signals: attribute_changed update

### DIFF
--- a/pragmatic/signals.py
+++ b/pragmatic/signals.py
@@ -169,7 +169,7 @@ class SignalsHelper(object):
             return None
 
     @staticmethod
-    def attribute_changed(instance, diff_fields, diff_contains={}):
+    def attribute_changed(instance, diff_fields, diff_contains={}, obj_exists=False):
         '''
         diff_fields: list of field names
         diff_contains: either {field_name: [vaue_1, value_2, ...]} or {field_name: {'from': [old_value_1, ...], 'to': [new_value_1, ...]}}
@@ -178,6 +178,9 @@ class SignalsHelper(object):
 
         if not obj:
             # new object
+            if obj_exists:
+                return False
+
             return True
 
         # object existed before, check difference


### PR DESCRIPTION
added obj_exists attribute to SignalHelper.attribute_changed to be able to require obj exists already in db, distinguishing strict update (not creation)