### PR TITLE
Corrected MultiSelectField.get_db_prep_value string validation check

### DIFF
--- a/pragmatic/fields.py
+++ b/pragmatic/fields.py
@@ -11,7 +11,6 @@ from django.core.validators import EMPTY_VALUES
 from django.utils.encoding import smart_str
 from django.utils.translation import gettext_lazy as _
 
-from django_filters.constants import EMPTY_VALUES
 from django_filters.fields import BaseRangeField, BaseCSVField
 from pragmatic.widgets import SliderWidget
 
@@ -178,7 +177,7 @@ class MultiSelectField(models.Field):
         return value
 
     def get_db_prep_value(self, value, connection=None, prepared=False):
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             return value
         elif isinstance(value, list):
             return ",".join(value)


### PR DESCRIPTION
Two changes are made:

1. `MultiSelectField.get_db_prep_value` - Replaced Python 2 `basestring` to Python 3 `str` in the check
2. There are two conflicting imports for `EMPTY_VALUES` within the file which are equivalent to each other. This change will use the Django core's definition instead of the one used in django-filter. Compare the following:

    - (Django 4.2) https://github.com/django/django/blob/4.2.7/django/core/validators.py#L16
    - (django-filter) https://github.com/carltongibson/django-filter/blob/main/django_filters/constants.py#L4